### PR TITLE
Update method names in the Browser interface

### DIFF
--- a/script-api/pizzascript.js
+++ b/script-api/pizzascript.js
@@ -319,7 +319,7 @@ assert.eq = function(o1, o2) {};
  *
  * @example
  * // Check that an input element is not set to 42
- * assert.eq(b.getValue("#input1"), "42");
+ * assert.notEqual(b.getValue("#input1"), "42");
  *
  * @throws Throws an assertion when o1 is equal o2
  */
@@ -330,7 +330,7 @@ assert.notEqual = function(o1, o2) {};
  *
  * @example
  * // Check that an input element is not set to 42
- * assert.eq(b.getValue("#input1"), "42");
+ * assert.ne(b.getValue("#input1"), "42");
  *
  * @param {Object} o1
  * @param {Object} o2

--- a/script-api/pizzascript.js
+++ b/script-api/pizzascript.js
@@ -1416,26 +1416,26 @@ Browser.prototype.setValue = function(selector, value) {};
  * Get the html inside the given element
  *
  * @example
- * var html = b.getInnerHTML('#input1');
+ * var html = b.getInnerHtml('#input1');
  *
  * @param {String} selector the element to get the HTML from
  * @return {String} the inner HTML for the given element
  * @throws Throws an exception if the element can not be found
  */
-Browser.prototype.getInnerHTML = function(selector) {};
+Browser.prototype.getInnerHtml = function(selector) {};
 
 /**
  * Get the html for the given element or the entire frame if
  * no element specified.
  *
  * @example
- * var html = b.getInnerHTML();
+ * var html = b.getInnerHtml();
  *
  * @param {String=} selector the element to get the HTML for
  * @return {String} the outer HTML for the given element
  * @throws Throws an exception if the element can not be found
  */
-Browser.prototype.getOuterHTML = function(selector) {};
+Browser.prototype.getOuterHtml = function(selector) {};
 
 /**
  * Get the text inside the given element

--- a/script-api/src/main/java/com/loadtestgo/script/api/Browser.java
+++ b/script-api/src/main/java/com/loadtestgo/script/api/Browser.java
@@ -646,7 +646,7 @@ public interface Browser {
      * @param selector the element to get the HTML from
      * @return the inner HTML for the given element
      */
-    String getInnerHTML(String selector);
+    String getInnerHtml(String selector);
 
     /**
      * Get the html for the given element
@@ -654,7 +654,7 @@ public interface Browser {
      * @param selector the element to get the HTML for
      * @return the outer HTML for the given element
      */
-    String getOuterHTML(String selector);
+    String getOuterHtml(String selector);
 
     /**
      * Get the html for the entire currently selected frame.
@@ -663,7 +663,7 @@ public interface Browser {
      *
      * @return the outer HTML for the current frame.
      */
-    String getOuterHTML();
+    String getOuterHtml();
 
     /**
      * Get the text inside the given element

--- a/scripts/basic.js
+++ b/scripts/basic.js
@@ -1,2 +1,7 @@
+// Open the browser and navigate to the requested URL
+// NOTE: A browser instance can be opened without initially
+// setting the URL, see script: sitelogin.js
 b = pizza.open("www.google.com");
+
+// Verify the following text exists on the page
 b.verifyText("Google");

--- a/scripts/dig.js
+++ b/scripts/dig.js
@@ -1,0 +1,26 @@
+var b = pizza.open('https://toolbox.googleapps.com/apps/dig/');
+
+pizza.sleep(1000);
+// b.waitPageLoad();  // script has been getting hung up
+
+var domains = ['walmart.com', 'amazon.com'];
+
+b.type('#domain', domains[Math.floor((Math.random() * domains.length - 1) + 1)]);
+
+b.click('xpath://input[@value="NS"]');
+
+b.waitForVisible('#response-text');
+
+var html = b.getInnerHTML('xpath://*[@id="response-text"]');
+
+var re = /href="(.*?)"/g;
+
+var authNameServers = [];
+
+while(match = re.exec(html)){
+
+    authNameServers.push(match[1].split('@')[1]);
+
+}
+
+console.log(authNameServers);

--- a/scripts/dig.js
+++ b/scripts/dig.js
@@ -7,7 +7,8 @@ var domains = ['walmart.com', 'amazon.com'];
 
 b.type('#domain', domains[Math.floor((Math.random() * domains.length - 1) + 1)]);
 
-b.click('xpath://input[@value="NS"]');
+var records = ['A', 'AAAA', 'ANY', 'CNAME', 'MX', 'NS', 'PTR', 'SOA', 'SRV', 'TXT'];
+b.click('xpath://input[@value="' + records[5] + '"]');
 
 b.waitForVisible('#response-text');
 

--- a/scripts/dig.js
+++ b/scripts/dig.js
@@ -1,27 +1,26 @@
-var b = pizza.open('https://toolbox.googleapps.com/apps/dig/');
+var b = pizza.open("https://toolbox.googleapps.com/apps/dig/");
 
-pizza.sleep(1000);
-// b.waitPageLoad();  // script has been getting hung up
+b.waitForVisible("#domain");
 
-var domains = ['walmart.com', 'amazon.com'];
+var domains = ["walmart.com", "amazon.com"];
 
-b.type('#domain', domains[Math.floor((Math.random() * domains.length - 1) + 1)]);
+b.type("#domain",utils.randomElement(domains));
 
-var records = ['A', 'AAAA', 'ANY', 'CNAME', 'MX', 'NS', 'PTR', 'SOA', 'SRV', 'TXT'];
-b.click('xpath://input[@value="' + records[5] + '"]');
+var records = ["A", "AAAA", "ANY", "CNAME", "MX", "NS", "PTR", "SOA", "SRV", "TXT"];
+
+// b.click("xpath://input[@value=\"" + records[5] + "\"]");
+b.click("input[value=\"" + records[5] + "\"]");
 
 b.waitForVisible('#response-text');
 
-var html = b.getInnerHTML('xpath://*[@id="response-text"]');
+var html = b.getInnerHTML('#response-text');
 
 var re = /href="(.*?)"/g;
 
 var authNameServers = [];
 
 while(match = re.exec(html)){
-
-    authNameServers.push(match[1].split('@')[1]);
-
+    authNameServers.push(match[1].split("@")[1]);
 }
 
 console.log(authNameServers);


### PR DESCRIPTION
Propose update to method names ending in "HTML" to "Html" to be consistent with other methods like ignoreHttpErrors or selectFrameCss